### PR TITLE
Acceleration with for-loop reduction

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+filename = *.py
+ignore = H903

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+dist/
+build/
+smlr.egg-info/

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ python setup.py install
 ``` python
 import smlr
 
-model = smlr.SMLR(max_iter=1000,tol=1e-5,verbose=1)
+model = smlr.SMLR(max_iter=1000, tol=1e-5, verbose=1)
 model.fit(x, y)
 model.predict(x_test)
 ```

--- a/demoSMLR_20140714.py
+++ b/demoSMLR_20140714.py
@@ -58,13 +58,13 @@ pylab.ylim(-3, 3)
 matplotlib.pyplot.show()
 
 # SMLR & SVM training
-print "SMLR learning"
+print("SMLR learning")
 smlr.fit(feature4training, label4training)
-print "SVM learning"
+print("SVM learning")
 svm.fit(feature4training, label4training)
 
-print "The SLMR weights obtained"
-print numpy.transpose(smlr.coef_)
+print("The SLMR weights obtained")
+print(numpy.transpose(smlr.coef_))
 
 # Linear boundary in the feature space
 for n in range(len(label4training)):
@@ -102,5 +102,5 @@ for n in range(len(label4test)):
 
 smlr_accuracy = numpy.double(num_correct) / len(label4test) * 100
 
-print "SVM accuracy: %s" % (svm_accuracy)
-print "SMLR accuracy: %s" % (smlr_accuracy)
+print("SVM accuracy: %s" % (svm_accuracy))
+print("SMLR accuracy: %s" % (smlr_accuracy))

--- a/demoSMLR_20170617.py
+++ b/demoSMLR_20170617.py
@@ -5,7 +5,7 @@ demoSMLR_20140714
 
 from __future__ import print_function
 
-import matplotlib.pyplot as plt
+import matplotlib.pyplot
 import numpy
 import sklearn.svm
 
@@ -38,24 +38,23 @@ feature4test = numpy.vstack(((
 
 numpy.random.seed(seed=1)
 
-feature4training = feature4training + \
-    0.5 * numpy.random.randn(*feature4training.shape)
-feature4test = feature4test + 0.5 * numpy.random.randn(*feature4test.shape)
+feature4training += 0.5 * numpy.random.randn(*feature4training.shape)
+feature4test += 0.5 * numpy.random.randn(*feature4test.shape)
 
 # Scatter plot in the feature space
 for n in range(len(label4training)):
     if label4training[n] == 0:
-        plt.scatter(
+        matplotlib.pyplot.scatter(
             feature4training[n, 0], feature4training[n, 1], color='red')
     else:
-        plt.scatter(
+        matplotlib.pyplot.scatter(
             feature4training[n, 0], feature4training[n, 1], color='blue')
 
-plt.xlabel("Dimension 1")
-plt.ylabel("Dimension 2")
-plt.xlim(-3, 3)
-plt.ylim(-3, 3)
-plt.show()
+matplotlib.pyplot.xlabel("Dimension 1")
+matplotlib.pyplot.ylabel("Dimension 2")
+matplotlib.pyplot.xlim(-3, 3)
+matplotlib.pyplot.ylim(-3, 3)
+matplotlib.pyplot.show()
 
 # SMLR & SVM training
 print("SMLR learning")
@@ -69,21 +68,21 @@ print(numpy.transpose(smlr.coef_))
 # Linear boundary in the feature space
 for n in range(len(label4training)):
     if label4training[n] == 0:
-        plt.scatter(
+        matplotlib.pyplot.scatter(
             feature4training[n, 0], feature4training[n, 1], color='red')
     else:
-        plt.scatter(
+        matplotlib.pyplot.scatter(
             feature4training[n, 0], feature4training[n, 1], color='blue')
 
-plt.xlabel("Dimension 1")
-plt.ylabel("Dimension 2")
+matplotlib.pyplot.xlabel("Dimension 1")
+matplotlib.pyplot.ylabel("Dimension 2")
 w = smlr.coef_[0, :]
 x = numpy.arange(-5, 5, 0.001)
 y = (-w[-1] - x * w[0]) / w[1]
-plt.plot(x, y, color='black')
-plt.xlim(-3, 3)
-plt.ylim(-3, 3)
-plt.show()
+matplotlib.pyplot.plot(x, y, color='black')
+matplotlib.pyplot.xlim(-3, 3)
+matplotlib.pyplot.ylim(-3, 3)
+matplotlib.pyplot.show()
 
 # generalization test
 predictedLabelBySVM = svm.predict(feature4test)
@@ -92,14 +91,14 @@ predictedLabelBySMLR = smlr.predict(feature4test)
 num_correct = 0
 for n in range(len(label4test)):
     if label4test[n] == predictedLabelBySVM[n]:
-        num_correct = num_correct + 1
+        num_correct += 1
 
 svm_accuracy = numpy.double(num_correct) / len(label4test) * 100
 
 num_correct = 0
 for n in range(len(label4test)):
     if label4test[n] == predictedLabelBySMLR[n]:
-        num_correct = num_correct + 1
+        num_correct += 1
 
 smlr_accuracy = numpy.double(num_correct) / len(label4test) * 100
 

--- a/demoSMLR_20170617.py
+++ b/demoSMLR_20170617.py
@@ -3,6 +3,7 @@
 demoSMLR_20140714
 '''
 
+from __future__ import print_function
 
 import numpy
 import sklearn.svm

--- a/demoSMLR_20170617.py
+++ b/demoSMLR_20170617.py
@@ -5,19 +5,18 @@ demoSMLR_20140714
 
 from __future__ import print_function
 
+import matplotlib.pyplot as plt
 import numpy
 import sklearn.svm
-import matplotlib.pyplot
 
 import smlr
-import pylab
 
 
-## Prepare classifier objects
+# Prepare classifier objects
 svm = sklearn.svm.LinearSVC()
-smlr = smlr.SMLR(max_iter=1000,tol=1e-5,verbose=1)
+smlr = smlr.SMLR(max_iter=1000, tol=1e-5, verbose=1)
 
-## Sample data generation
+# Sample data generation
 
 # Num of samples
 N = 100
@@ -30,33 +29,33 @@ label4test = numpy.vstack((numpy.zeros((N, 1)), numpy.ones((N, 1))))
 feature4class1 = numpy.array([1, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 feature4class2 = numpy.array([-1, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
-feature4training = numpy.vstack(((numpy.dot(numpy.ones((N, 1)), [feature4class1]),
-                                  numpy.dot(numpy.ones((N, 1)), [feature4class2]))))
-feature4test = numpy.vstack(((numpy.dot(numpy.ones((N, 1)), [feature4class1]),
-                              numpy.dot(numpy.ones((N, 1)), [feature4class2]))))
+feature4training = numpy.vstack(((
+    numpy.dot(numpy.ones((N, 1)), [feature4class1]),
+    numpy.dot(numpy.ones((N, 1)), [feature4class2]))))
+feature4test = numpy.vstack(((
+    numpy.dot(numpy.ones((N, 1)), [feature4class1]),
+    numpy.dot(numpy.ones((N, 1)), [feature4class2]))))
 
-#import numpy.random
 numpy.random.seed(seed=1)
 
-feature4training = feature4training \
-                   + 0.5 * numpy.random.randn(feature4training.shape[0], feature4training.shape[1])
-feature4test = feature4test \
-               + 0.5 * numpy.random.randn(feature4test.shape[0], feature4test.shape[1])
+feature4training = feature4training + \
+    0.5 * numpy.random.randn(*feature4training.shape)
+feature4test = feature4test + 0.5 * numpy.random.randn(*feature4test.shape)
 
 # Scatter plot in the feature space
-
 for n in range(len(label4training)):
     if label4training[n] == 0:
-        matplotlib.pyplot.scatter(feature4training[n, 0], feature4training[n, 1], color='red')
+        plt.scatter(
+            feature4training[n, 0], feature4training[n, 1], color='red')
     else:
-        matplotlib.pyplot.scatter(feature4training[n, 0], feature4training[n, 1], color='blue')
+        plt.scatter(
+            feature4training[n, 0], feature4training[n, 1], color='blue')
 
-matplotlib.pyplot.xlabel("Dimension 1")
-matplotlib.pyplot.ylabel("Dimension 2")
-
-pylab.xlim(-3, 3)
-pylab.ylim(-3, 3)
-matplotlib.pyplot.show()
+plt.xlabel("Dimension 1")
+plt.ylabel("Dimension 2")
+plt.xlim(-3, 3)
+plt.ylim(-3, 3)
+plt.show()
 
 # SMLR & SVM training
 print("SMLR learning")
@@ -70,21 +69,23 @@ print(numpy.transpose(smlr.coef_))
 # Linear boundary in the feature space
 for n in range(len(label4training)):
     if label4training[n] == 0:
-        matplotlib.pyplot.scatter(feature4training[n, 0], feature4training[n, 1], color='red')
+        plt.scatter(
+            feature4training[n, 0], feature4training[n, 1], color='red')
     else:
-        matplotlib.pyplot.scatter(feature4training[n, 0], feature4training[n, 1], color='blue')
+        plt.scatter(
+            feature4training[n, 0], feature4training[n, 1], color='blue')
 
-matplotlib.pyplot.xlabel("Dimension 1")
-matplotlib.pyplot.ylabel("Dimension 2")
+plt.xlabel("Dimension 1")
+plt.ylabel("Dimension 2")
 w = smlr.coef_[0, :]
 x = numpy.arange(-5, 5, 0.001)
 y = (-w[-1] - x * w[0]) / w[1]
-matplotlib.pyplot.plot(x, y, color='black')
-pylab.xlim(-3, 3)
-pylab.ylim(-3, 3)
-matplotlib.pyplot.show()
+plt.plot(x, y, color='black')
+plt.xlim(-3, 3)
+plt.ylim(-3, 3)
+plt.show()
 
-#generalization test
+# generalization test
 predictedLabelBySVM = svm.predict(feature4test)
 predictedLabelBySMLR = smlr.predict(feature4test)
 
@@ -96,7 +97,6 @@ for n in range(len(label4test)):
 svm_accuracy = numpy.double(num_correct) / len(label4test) * 100
 
 num_correct = 0
-
 for n in range(len(label4test)):
     if label4test[n] == predictedLabelBySMLR[n]:
         num_correct = num_correct + 1

--- a/smlr/SMLR.py
+++ b/smlr/SMLR.py
@@ -159,41 +159,26 @@ class SMLR(BaseEstimator, ClassifierMixin):
             C: array, shape = [n_samples]
                 Predicted class label per sample.
         """
-        N = feature.shape[0]
-        D = feature.shape[1]
 
         # add a bias term to feature
-        feature = numpy.hstack((feature, numpy.ones((N, 1))))
+        feature = numpy.hstack((feature, numpy.ones((feature.shape[0], 1))))
 
         # load weights
         w = numpy.vstack((numpy.transpose(self.coef_), self.intercept_))
-        C = w.shape[1]
 
         # predictive probability calculation
-        p = numpy.zeros((N, C))
-        predicted_label = list([])
-        for n in range(N):
-            p[n, :] = numpy.exp(numpy.dot(feature[n, :], w))
-            p[n, :] = p[n, :] / sum(p[n, :])
-            predicted_label.append(self.classes_[numpy.argmax(p[n, :])])
-        return numpy.array(predicted_label)
+        p = numpy.exp(feature.dot(w))
+        p /= p.sum(axis=1)[:, numpy.newaxis]
+        return self.classes_[numpy.argmax(p, axis=1)]
 
     def decision_function(self, feature):
-        N = feature.shape[0]
-        D = feature.shape[1]
-
         #add a bias term to feature
-        feature = numpy.hstack((feature, numpy.ones((N, 1))))
+        feature = numpy.hstack((feature, numpy.ones((feature.shape[0], 1))))
 
         #load weights
         w = numpy.vstack((numpy.transpose(self.coef_), self.intercept_))
-        C = w.shape[1]
 
-        #predictive probability calculation
-        decisionValue = numpy.zeros((N, C))
-        for n in range(N):
-            decisionValue[n, :] = numpy.dot(feature[n, :], w)
-        return decisionValue
+        return feature.dot(w)
 
     def predict_proba(self, feature):
         """Probability estimates.
@@ -210,22 +195,16 @@ class SMLR(BaseEstimator, ClassifierMixin):
                 in the model, where classes are ordered as they are in 
                 ``self.classes_``.
         """
-        N = feature.shape[0]
-        D = feature.shape[1]
 
         # add a bias term to feature
-        feature = numpy.hstack((feature, numpy.ones((N, 1))))
+        feature = numpy.hstack((feature, numpy.ones((feature.shape[0], 1))))
 
         # load weights
         w = numpy.vstack((numpy.transpose(self.coef_), self.intercept_))
-        C = w.shape[1]
 
         # predictive probability calculation
-        p = numpy.zeros((N, C))
-        predicted_label = numpy.zeros(N)
-        for n in range(N):
-            p[n, :] = numpy.exp(numpy.dot(feature[n, :], w))
-            p[n, :] = p[n, :] / sum(p[n, :])
+        p = numpy.exp(feature.dot(w))
+        p /= p.sum(axis=1)[:, numpy.newaxis]
         return p
 
     def predict_log_proba(self, feature):

--- a/smlr/SMLR.py
+++ b/smlr/SMLR.py
@@ -5,20 +5,21 @@ SMLR (sparse multinomial logistic regression)
 from __future__ import print_function
 
 import numpy
-from sklearn.base import BaseEstimator, ClassifierMixin
+from sklearn.base import BaseEstimator
+from sklearn.base import ClassifierMixin
 from smlr import SMLRupdate
 
 
 class SMLR(BaseEstimator, ClassifierMixin):
     """Sparce Multinomial Logistic Regression (SMLR) classifier.
 
-    The API of this function is compatible with the logistic regression in 
+    The API of this function is compatible with the logistic regression in
     scikit-learn.
 
     Parameters:
         max_iter: The maximum number of iterations in training
             (default 1000; int).
-        n_iter: The number of iterations in training (default 100). 
+        n_iter: The number of iterations in training (default 100).
         verbose: If 1, print verbose information (default).
 
     Attributes:
@@ -28,11 +29,11 @@ class SMLR(BaseEstimator, ClassifierMixin):
             Intercept (a.k.a. bias) added to the decision function.
 
     References:
-        Sparse estimation automatically selects voxels relevant for the 
+        Sparse estimation automatically selects voxels relevant for the
         decoding of fMRI activity patterns.
         Yamashita O, Sato MA, Yoshioka T, Tong F, Kamitani Y.
         Neuroimage. 2008.
-        doi: 10.1016/j.neuroimage.2008.05.050.    
+        doi: 10.1016/j.neuroimage.2008.05.050.
 
     """
 
@@ -47,12 +48,12 @@ class SMLR(BaseEstimator, ClassifierMixin):
     def fit(self, feature, label):
         """fit(self, feature, label) method of SMLR instance
 
-        Fit the model according to the given training data (in the same way as 
+        Fit the model according to the given training data (in the same way as
         logistic.py in sklearn).
 
         Parameters:
             feature: array-like, shape = [n_samples, n_features]
-                    Training vector, where n_samples in the number of samples 
+                    Training vector, where n_samples in the number of samples
                     and n_features is the number of features.
             label: array-like, shape = [n_samples]
                     Target vector for "feature"
@@ -87,7 +88,8 @@ class SMLR(BaseEstimator, ClassifierMixin):
         feature = numpy.hstack((feature, numpy.ones((N, 1))))
         D = D + 1
 
-        # set initial values of theta (wieghts) and alpha (relavence parameters)
+        # set initial values of theta (wieghts) and
+        # alpha (relavence parameters)
         theta = numpy.zeros((D, C))
         alpha = numpy.ones((D, C))
         isEffective = numpy.ones((D, C))
@@ -147,11 +149,11 @@ class SMLR(BaseEstimator, ClassifierMixin):
     def predict(self, feature):
         """predict(self, feature) method of SMLR instance
 
-        Predict class labels for samples in feature (in the same way as 
+        Predict class labels for samples in feature (in the same way as
         logistic.py in sklearn).
 
         Parameters:
-            feature: {array-like, sparse matrix}, 
+            feature: {array-like, sparse matrix},
                 shape = [n_samples, n_features]
                 Samples.
 
@@ -172,10 +174,10 @@ class SMLR(BaseEstimator, ClassifierMixin):
         return self.classes_[numpy.argmax(p, axis=1)]
 
     def decision_function(self, feature):
-        #add a bias term to feature
+        # add a bias term to feature
         feature = numpy.hstack((feature, numpy.ones((feature.shape[0], 1))))
 
-        #load weights
+        # load weights
         w = numpy.vstack((numpy.transpose(self.coef_), self.intercept_))
 
         return feature.dot(w)
@@ -191,8 +193,8 @@ class SMLR(BaseEstimator, ClassifierMixin):
 
         Returns:
             T: array-like, shape = [n_samples, n_classes]
-                Returns the probability of the sample for each class 
-                in the model, where classes are ordered as they are in 
+                Returns the probability of the sample for each class
+                in the model, where classes are ordered as they are in
                 ``self.classes_``.
         """
 
@@ -218,7 +220,7 @@ class SMLR(BaseEstimator, ClassifierMixin):
 
         Returns:
             T: array-like, shape = [n_samples, n_classes]
-                Returns the log-probability of the sample for each class 
+                Returns the log-probability of the sample for each class
                 in the model, where classes are ordered as they are in
                 ``self.classes_``.
         """

--- a/smlr/SMLR.py
+++ b/smlr/SMLR.py
@@ -38,7 +38,7 @@ class SMLR(BaseEstimator, ClassifierMixin):
         self.max_iter = max_iter
         self.tol = tol
         self.verbose = verbose
-        #self.densify
+        # self.densify
 
         print("SMLR (sparse multinomial logistic regression)")
 
@@ -123,18 +123,14 @@ class SMLR(BaseEstimator, ClassifierMixin):
             effectiveFeature = numpy.delete(
                 effectiveFeature, dim_excluded, axis=0)
 
-            #show progress
+            # show progress
             if self.verbose:
-                #if (iteration+1)%numpy.round(self.max_iter*0.2) ==0 or iteration == 0:
-                #    num_effectiveWeights=numpy.sum(isEffective)
-                #    print "# of iterations: %d ,  # of effective dimensions: %d" %(iteration+1, len(effectiveFeature))
                 if not num_effectiveWeights == numpy.sum(isEffective):
                     num_effectiveWeights = numpy.sum(isEffective)
-                    print("# of iterations: %d ,  # of effective dimensions: %d"
-                        % (iteration + 1, len(effectiveFeature)))
-                    print("# of iterations: %d ,  FuncValue: %f"
-                        % (iteration + 1, newThetaParam['funcValue']))
-                    #print " "
+                    print("# of iterations: %d,  # of effective dimensions: %d"
+                          % (iteration + 1, len(effectiveFeature)))
+                    print("# of iterations: %d,  FuncValue: %f"
+                          % (iteration + 1, newThetaParam['funcValue']))
             if iteration > 1 and abs(funcValue - funcValue_pre) < self.tol:
                 break
 

--- a/smlr/SMLR.py
+++ b/smlr/SMLR.py
@@ -86,7 +86,7 @@ class SMLR(BaseEstimator, ClassifierMixin):
 
         # add a bias term to feature
         feature = numpy.hstack((feature, numpy.ones((N, 1))))
-        D = D + 1
+        D += 1
 
         # set initial values of theta (wieghts) and
         # alpha (relavence parameters)
@@ -171,7 +171,8 @@ class SMLR(BaseEstimator, ClassifierMixin):
         # predictive probability calculation
         p = numpy.exp(feature.dot(w))
         p /= p.sum(axis=1)[:, numpy.newaxis]
-        return self.classes_[numpy.argmax(p, axis=1)]
+        predicted_label = self.classes_[numpy.argmax(p, axis=1)]
+        return numpy.array(predicted_label)
 
     def decision_function(self, feature):
         # add a bias term to feature

--- a/smlr/SMLR.py
+++ b/smlr/SMLR.py
@@ -90,6 +90,7 @@ class SMLR(BaseEstimator, ClassifierMixin):
         alpha = numpy.ones((D, C))
         isEffective = numpy.ones((D, C))
         effectiveFeature = range(D)
+        num_effectiveWeights = numpy.sum(isEffective)
 
         # Variational baysian method (see Yamashita et al., 2008)
         for iteration in range(self.max_iter):
@@ -98,6 +99,12 @@ class SMLR(BaseEstimator, ClassifierMixin):
             newThetaParam = SMLRupdate.thetaStep(
                 theta, alpha, label_1ofK, feature, isEffective)
             theta = newThetaParam['mu']  # the posterior mean of theta
+            if iteration == 0:
+                funcValue_pre = newThetaParam['funcValue']
+                funcValue = newThetaParam['funcValue']
+            else:
+                funcValue_pre = funcValue
+                funcValue = newThetaParam['funcValue']
 
             # alpha-step
             alpha = SMLRupdate.alphaStep(
@@ -123,13 +130,13 @@ class SMLR(BaseEstimator, ClassifierMixin):
                 #    print "# of iterations: %d ,  # of effective dimensions: %d" %(iteration+1, len(effectiveFeature))
                 if not num_effectiveWeights == numpy.sum(isEffective):
                     num_effectiveWeights = numpy.sum(isEffective)
-                    print("# of iterations: %d ,  # of effective dimensions: %d")
-                        % (iteration + 1, len(effectiveFeature))
-                    print("# of iterations: %d ,  FuncValue: %f")
-                        % (iteration + 1, newThetaParam['funcValue'])
+                    print("# of iterations: %d ,  # of effective dimensions: %d"
+                        % (iteration + 1, len(effectiveFeature)))
+                    print("# of iterations: %d ,  FuncValue: %f"
+                        % (iteration + 1, newThetaParam['funcValue']))
                     #print " "
             if iteration > 1 and abs(funcValue - funcValue_pre) < self.tol:
-			break
+                break
 
         temporal_theta = numpy.zeros((D, C))
         temporal_theta[effectiveFeature, :] = theta

--- a/smlr/SMLR.py
+++ b/smlr/SMLR.py
@@ -2,6 +2,8 @@
 SMLR (sparse multinomial logistic regression)
 """
 
+from __future__ import print_function
+
 import numpy
 from sklearn.base import BaseEstimator, ClassifierMixin
 from smlr import SMLRupdate

--- a/smlr/SMLR.py
+++ b/smlr/SMLR.py
@@ -24,8 +24,8 @@ class SMLR(BaseEstimator, ClassifierMixin):
             Intercept (a.k.a. bias) added to the decision function.
 
     References:
-        Sparse estimation automatically selects voxels relevant for the decoding of
-        fMRI activity patterns.
+        Sparse estimation automatically selects voxels relevant for the 
+        decoding of fMRI activity patterns.
         Yamashita O, Sato MA, Yoshioka T, Tong F, Kamitani Y.
         Neuroimage. 2008.
         doi: 10.1016/j.neuroimage.2008.05.050.    
@@ -47,8 +47,8 @@ class SMLR(BaseEstimator, ClassifierMixin):
 
         Parameters:
             feature: array-like, shape = [n_samples, n_features]
-                    Training vector, where n_samples in the number of samples and
-                    n_features is the number of features.
+                    Training vector, where n_samples in the number of samples 
+                    and n_features is the number of features.
             label: array-like, shape = [n_samples]
                     Target vector for "feature"
 
@@ -92,8 +92,12 @@ class SMLR(BaseEstimator, ClassifierMixin):
         for iteration in range(self.n_iter):
 
             # theta-step
+            import time
+            start = time.time()
             newThetaParam = SMLRupdate.thetaStep(
                 theta, alpha, label_1ofK, feature, isEffective)
+            end = time.time()
+            print(end - start)
             theta = newThetaParam['mu']  # the posterior mean of theta
 
             # alpha-step
@@ -102,12 +106,10 @@ class SMLR(BaseEstimator, ClassifierMixin):
 
             # pruning of irrelevant dimensions (that have large alpha values)
             isEffective = numpy.ones(theta.shape)
-            isEffective[alpha > 10**3] = 0
-            theta[alpha > 10**3] = 0
+            isEffective[alpha > 1e+3] = 0
+            theta[alpha > 1e+3] = 0
 
-            dim_excluded = (numpy.all(isEffective == 0, axis=1))
-            dim_excluded = [d for d in range(len(dim_excluded))
-                            if dim_excluded[d]]
+            dim_excluded = numpy.where(numpy.all(isEffective == 0, axis=1))
             theta = numpy.delete(theta, dim_excluded, axis=0)
             alpha = numpy.delete(alpha, dim_excluded, axis=0)
             feature = numpy.delete(feature, dim_excluded, axis=1)

--- a/smlr/SMLR.py
+++ b/smlr/SMLR.py
@@ -2,168 +2,166 @@
 SMLR (sparse multinomial logistic regression)
 """
 
-
 import numpy
 from sklearn.base import BaseEstimator, ClassifierMixin
 from smlr import SMLRupdate
+
+
 class SMLR(BaseEstimator, ClassifierMixin):
     """Sparce Multinomial Logistic Regression (SMLR) classifier.
-	The API of this function is compatible with the logistic regression in scikit-learn.
 
-    Parameters
-    ----------
-    n_iter: The number of iterations in training (default 100). 
-    
-    verbose: If 1, print verbose information (default).
+    The API of this function is compatible with the logistic regression in 
+    scikit-learn.
 
-    Attributes
-    ----------
-    `coef_` : array, shape = [n_classes, n_features]
-        Coefficient of the features in the decision function.
+    Parameters:
+        n_iter: The number of iterations in training (default 100). 
+        verbose: If 1, print verbose information (default).
 
-    `intercept_` : array, shape = [n_classes]
-        Intercept (a.k.a. bias) added to the decision function.
-
+    Attributes:
+        `coef_`: array, shape = [n_classes, n_features]
+            Coefficient of the features in the decision function.
+        `intercept_`: array, shape = [n_classes]
+            Intercept (a.k.a. bias) added to the decision function.
 
     References:
-	Sparse estimation automatically selects voxels relevant for the decoding of fMRI activity patterns.
-	Yamashita O, Sato MA, Yoshioka T, Tong F, Kamitani Y.
-	Neuroimage. 2008.
-	doi: 10.1016/j.neuroimage.2008.05.050.    
-	
-	
+        Sparse estimation automatically selects voxels relevant for the decoding of
+        fMRI activity patterns.
+        Yamashita O, Sato MA, Yoshioka T, Tong F, Kamitani Y.
+        Neuroimage. 2008.
+        doi: 10.1016/j.neuroimage.2008.05.050.    
+
     """
 
-
-
-    def __init__(self, n_iter=1000,verbose=1):
-        self.n_iter=n_iter
+    def __init__(self, n_iter=1000, verbose=1):
+        self.n_iter = n_iter
         self.verbose = verbose
-        #self.densify
+        # self.densify
 
         print("SMLR (sparse multinomial logistic regression)")
-    
-    def fit(self,feature,label):
+
+    def fit(self, feature, label):
         """fit(self, feature, label) method of SMLR instance
-        Fit the model according to the given training data (in the same way as logistic.py in sklearn).
-    
-    	Parameters
-    	----------
-    	feature : array-like, shape = [n_samples, n_features]
-        	Training vector, where n_samples in the number of samples and
-        	n_features is the number of features.
-    
-    	label : array-like, shape = [n_samples]
-        	Target vector for "feature"
-    
-    	Returns
-    	-------
-    	self : object
-        Returns self.
+
+        Fit the model according to the given training data (in the same way as 
+        logistic.py in sklearn).
+
+        Parameters:
+            feature: array-like, shape = [n_samples, n_features]
+                    Training vector, where n_samples in the number of samples and
+                    n_features is the number of features.
+            label: array-like, shape = [n_samples]
+                    Target vector for "feature"
+
+        Returns:
+            self: object
+            Returns self.
         """
 
-        #feature: matrix, whose size is # of samples by # of dimensions.
-        #label: label vector, whose size is # of samples.
-        #       If you treat a classification problem with C classes, please use 0,1,2,...,(C-1) to indicate classes
-        
-        
-        #Check # of features, # of dimensions, and # of classes
-        self.classes_, indices = numpy.unique(label,return_inverse=True)
-        N=feature.shape[0]
-        D=feature.shape[1]
-        #C=numpy.max(label)+1
-        #C=C.astype(int)
-        C=len(self.classes_)
-        
-        #transoform label into a 1-d array to avoid possible errors
-        label=indices
-        
-        
-        #make class label based on 1-of-K representation
-        label_1ofK=numpy.zeros((N,C))
+        # feature: matrix, whose size is # of samples by # of dimensions.
+        # label: label vector, whose size is # of samples.
+        # If you treat a classification problem with C classes, please
+        # use 0,1,2,...,(C-1) to indicate classes
+
+        # Check # of features, # of dimensions, and # of classes
+        self.classes_, indices = numpy.unique(label, return_inverse=True)
+        N = feature.shape[0]
+        D = feature.shape[1]
+        # C=numpy.max(label)+1
+        # C=C.astype(int)
+        C = len(self.classes_)
+
+        # transoform label into a 1-d array to avoid possible errors
+        label = indices
+
+        # make class label based on 1-of-K representation
+        label_1ofK = numpy.zeros((N, C))
         for n in range(N):
-            label_1ofK[n,label[n]]=1
-    
-    
-        #add a bias term to feature
-        feature=numpy.hstack((feature,numpy.ones((N,1))))
-        D=D+1
-    
-        
-        #set initial values of theta (wieghts) and alpha (relavence parameters)
-        theta=numpy.zeros((D,C))
-        alpha=numpy.ones((D,C))
-        isEffective=numpy.ones((D,C))
-        effectiveFeature=range(D)
-        
-        #Variational baysian method (see Yamashita et al., 2008)
+            label_1ofK[n, label[n]] = 1
+
+        # add a bias term to feature
+        feature = numpy.hstack((feature, numpy.ones((N, 1))))
+        D = D + 1
+
+        # set initial values of theta (wieghts) and alpha (relavence parameters)
+        theta = numpy.zeros((D, C))
+        alpha = numpy.ones((D, C))
+        isEffective = numpy.ones((D, C))
+        effectiveFeature = range(D)
+
+        # Variational baysian method (see Yamashita et al., 2008)
         for iteration in range(self.n_iter):
-            
-            #theta-step
-            newThetaParam=SMLRupdate.thetaStep(theta,alpha,label_1ofK,feature,isEffective)
-            theta=newThetaParam['mu']#the posterior mean of theta
-            
-            #alpha-step
-            alpha=SMLRupdate.alphaStep(alpha,newThetaParam['mu'],newThetaParam['var'],isEffective)
-            
-            #pruning of irrelevant dimensions (that have large alpha values)
-            isEffective=numpy.ones(theta.shape)
-            isEffective[alpha>10**3]=0
-            theta[alpha>10**3]=0
-            
-            dim_excluded=(numpy.all(isEffective==0,axis=1))
-            dim_excluded=[d for d in range(len(dim_excluded)) if dim_excluded[d]]
-            theta=numpy.delete(theta,dim_excluded,axis=0)
-            alpha=numpy.delete(alpha,dim_excluded,axis=0)
-            feature=numpy.delete(feature,dim_excluded,axis=1)
-            isEffective=numpy.delete(isEffective,dim_excluded,axis=0)
-            effectiveFeature=numpy.delete(effectiveFeature,dim_excluded,axis=0)
-            
-            #show progress
+
+            # theta-step
+            newThetaParam = SMLRupdate.thetaStep(
+                theta, alpha, label_1ofK, feature, isEffective)
+            theta = newThetaParam['mu']  # the posterior mean of theta
+
+            # alpha-step
+            alpha = SMLRupdate.alphaStep(
+                alpha, newThetaParam['mu'], newThetaParam['var'], isEffective)
+
+            # pruning of irrelevant dimensions (that have large alpha values)
+            isEffective = numpy.ones(theta.shape)
+            isEffective[alpha > 10**3] = 0
+            theta[alpha > 10**3] = 0
+
+            dim_excluded = (numpy.all(isEffective == 0, axis=1))
+            dim_excluded = [d for d in range(len(dim_excluded))
+                            if dim_excluded[d]]
+            theta = numpy.delete(theta, dim_excluded, axis=0)
+            alpha = numpy.delete(alpha, dim_excluded, axis=0)
+            feature = numpy.delete(feature, dim_excluded, axis=1)
+            isEffective = numpy.delete(isEffective, dim_excluded, axis=0)
+            effectiveFeature = numpy.delete(
+                effectiveFeature, dim_excluded, axis=0)
+
+            # show progress
             if self.verbose:
-                if (iteration+1)%numpy.round(self.n_iter*0.2) ==0 or iteration == 0:
-                    num_effectiveWeights=numpy.sum(isEffective)
-                    print("# of iterations: %d ,  # of effective dimensions: %d" %(iteration+1, len(effectiveFeature)))
-    
-        temporal_theta=numpy.zeros((D,C))
-        temporal_theta[effectiveFeature,:]=theta
-        theta=temporal_theta
-                    
-        self.coef_=numpy.transpose(theta[:-1,:])
-        self.intercept_=theta[-1,:]
+                if (iteration + 1) % numpy.round(self.n_iter * 0.2) == 0 or iteration == 0:
+                    num_effectiveWeights = numpy.sum(isEffective)
+                    print("# of iterations: %d, # of effective dimensions: %d"
+                          % (iteration + 1, len(effectiveFeature)))
+
+        temporal_theta = numpy.zeros((D, C))
+        temporal_theta[effectiveFeature, :] = theta
+        theta = temporal_theta
+
+        self.coef_ = numpy.transpose(theta[:-1, :])
+        self.intercept_ = theta[-1, :]
         return theta
 
-    def predict(self,feature):
+    def predict(self, feature):
         """predict(self, feature) method of SMLR instance
- 	   Predict class labels for samples in feature (in the same way as logistic.py in sklearn).
-    
-    	Parameters
-    	----------
-    	feature : {array-like, sparse matrix}, shape = [n_samples, n_features]
-        	Samples.
-    
-    	Returns
-    	-------
-    	C : array, shape = [n_samples]
-        	Predicted class label per sample.
-	"""
-        N=feature.shape[0]
-        D=feature.shape[1]
-        
-        #add a bias term to feature
-        feature=numpy.hstack((feature,numpy.ones((N,1))))
-        
-        #load weights
-        w=numpy.vstack((numpy.transpose(self.coef_),self.intercept_))
-        C=w.shape[1]
-        
-        #predictive probability calculation
-        p=numpy.zeros((N,C))
-        predicted_label=list([])
+
+        Predict class labels for samples in feature (in the same way as 
+        logistic.py in sklearn).
+
+        Parameters:
+            feature: {array-like, sparse matrix}, 
+                shape = [n_samples, n_features]
+                Samples.
+
+        Returns:
+            C: array, shape = [n_samples]
+                Predicted class label per sample.
+        """
+        N = feature.shape[0]
+        D = feature.shape[1]
+
+        # add a bias term to feature
+        feature = numpy.hstack((feature, numpy.ones((N, 1))))
+
+        # load weights
+        w = numpy.vstack((numpy.transpose(self.coef_), self.intercept_))
+        C = w.shape[1]
+
+        # predictive probability calculation
+        p = numpy.zeros((N, C))
+        predicted_label = list([])
         for n in range(N):
-            p[n,:]=numpy.exp(numpy.dot(feature[n,:],w))
-            p[n,:]=p[n,:]/sum(p[n,:])
-            predicted_label.append(self.classes_[numpy.argmax(p[n,:])])
+            p[n, :] = numpy.exp(numpy.dot(feature[n, :], w))
+            p[n, :] = p[n, :] / sum(p[n, :])
+            predicted_label.append(self.classes_[numpy.argmax(p[n, :])])
         return predicted_label
 
 #    def decision_function(self, feature):
@@ -181,63 +179,56 @@ class SMLR(BaseEstimator, ClassifierMixin):
 #        decisionValue=numpy.zeros((N,C))
 #        for n in range(N):
 #            decisionValue[n,:]=numpy.dot(feature[n,:],w)
-#	
+#
 #	return decisionValue
 
-    def predict_proba(self,feature):
+    def predict_proba(self, feature):
         """Probability estimates.
 
         The returned estimates for all classes are ordered by the
         label of classes (in the same way as logistic.py in sklearn).
 
-        Parameters
-        ----------
-        feature : array-like, shape = [n_samples, n_features]
+        Parameters:
+            feature: array-like, shape = [n_samples, n_features]
 
-        Returns
-        -------
-        T : array-like, shape = [n_samples, n_classes]
-            Returns the probability of the sample for each class in the model,
-            where classes are ordered as they are in ``self.classes_``.
+        Returns:
+            T: array-like, shape = [n_samples, n_classes]
+                Returns the probability of the sample for each class 
+                in the model, where classes are ordered as they are in 
+                ``self.classes_``.
         """
+        N = feature.shape[0]
+        D = feature.shape[1]
 
-        N=feature.shape[0]
-        D=feature.shape[1]
-        
-        #add a bias term to feature
-        feature=numpy.hstack((feature,numpy.ones((N,1))))
-        
-        #load weights
-        w=numpy.vstack((numpy.transpose(self.coef_),self.intercept_))
-        C=w.shape[1]
-        
-        #predictive probability calculation
-        p=numpy.zeros((N,C))
-        predicted_label=numpy.zeros(N)
+        # add a bias term to feature
+        feature = numpy.hstack((feature, numpy.ones((N, 1))))
+
+        # load weights
+        w = numpy.vstack((numpy.transpose(self.coef_), self.intercept_))
+        C = w.shape[1]
+
+        # predictive probability calculation
+        p = numpy.zeros((N, C))
+        predicted_label = numpy.zeros(N)
         for n in range(N):
-            p[n,:]=numpy.exp(numpy.dot(feature[n,:],w))
-            p[n,:]=p[n,:]/sum(p[n,:])
+            p[n, :] = numpy.exp(numpy.dot(feature[n, :], w))
+            p[n, :] = p[n, :] / sum(p[n, :])
         return p
 
-    def predict_log_proba(self,feature):
+    def predict_log_proba(self, feature):
         """Log of probability estimates.
 
         The returned estimates for all classes are ordered by the
         label of classes (in the same way as logistic.py in sklearn).
 
-        Parameters
-        ----------
-        feature : array-like, shape = [n_samples, n_features]
+        Parameters:
+            feature: array-like, shape = [n_samples, n_features]
 
-        Returns
-        -------
-        T : array-like, shape = [n_samples, n_classes]
-            Returns the log-probability of the sample for each class in the
-            model, where classes are ordered as they are in ``self.classes_``.
+        Returns:
+            T: array-like, shape = [n_samples, n_classes]
+                Returns the log-probability of the sample for each class 
+                in the model, where classes are ordered as they are in
+                ``self.classes_``.
         """
-
         p = self.predict_proba(feature)
         return numpy.log(p)
-
-
-

--- a/smlr/SMLR.py
+++ b/smlr/SMLR.py
@@ -4,8 +4,8 @@ SMLR (sparse multinomial logistic regression)
 
 
 import numpy
-import SMLRupdate
 from sklearn.base import BaseEstimator, ClassifierMixin
+from smlr import SMLRupdate
 class SMLR(BaseEstimator, ClassifierMixin):
     """Sparce Multinomial Logistic Regression (SMLR) classifier.
 	The API of this function is compatible with the logistic regression in scikit-learn.
@@ -37,11 +37,11 @@ class SMLR(BaseEstimator, ClassifierMixin):
 
 
     def __init__(self, n_iter=1000,verbose=1):
-	self.n_iter=n_iter
-	self.verbose = verbose
-	#self.densify
+        self.n_iter=n_iter
+        self.verbose = verbose
+        #self.densify
 
-        print "SMLR (sparse multinomial logistic regression)"
+        print("SMLR (sparse multinomial logistic regression)")
     
     def fit(self,feature,label):
         """fit(self, feature, label) method of SMLR instance
@@ -123,7 +123,7 @@ class SMLR(BaseEstimator, ClassifierMixin):
             if self.verbose:
                 if (iteration+1)%numpy.round(self.n_iter*0.2) ==0 or iteration == 0:
                     num_effectiveWeights=numpy.sum(isEffective)
-                    print "# of iterations: %d ,  # of effective dimensions: %d" %(iteration+1, len(effectiveFeature))
+                    print("# of iterations: %d ,  # of effective dimensions: %d" %(iteration+1, len(effectiveFeature)))
     
         temporal_theta=numpy.zeros((D,C))
         temporal_theta[effectiveFeature,:]=theta
@@ -236,8 +236,8 @@ class SMLR(BaseEstimator, ClassifierMixin):
             model, where classes are ordered as they are in ``self.classes_``.
         """
 
-	p = self.predict_proba(feature)
-	return numpy.log(p)
+        p = self.predict_proba(feature)
+        return numpy.log(p)
 
 
 

--- a/smlr/SMLR.py
+++ b/smlr/SMLR.py
@@ -178,23 +178,22 @@ class SMLR(BaseEstimator, ClassifierMixin):
             predicted_label.append(self.classes_[numpy.argmax(p[n, :])])
         return numpy.array(predicted_label)
 
-#    def decision_function(self, feature):
-#        N=feature.shape[0]
-#        D=feature.shape[1]
-#
-#        #add a bias term to feature
-#        feature=numpy.hstack((feature,numpy.ones((N,1))))
-#
-#        #load weights
-#        w=numpy.vstack((numpy.transpose(self.coef_),self.intercept_))
-#        C=w.shape[1]
-#
-#        #predictive probability calculation
-#        decisionValue=numpy.zeros((N,C))
-#        for n in range(N):
-#            decisionValue[n,:]=numpy.dot(feature[n,:],w)
-#
-#	return decisionValue
+    def decision_function(self, feature):
+        N = feature.shape[0]
+        D = feature.shape[1]
+
+        #add a bias term to feature
+        feature = numpy.hstack((feature, numpy.ones((N, 1))))
+
+        #load weights
+        w = numpy.vstack((numpy.transpose(self.coef_), self.intercept_))
+        C = w.shape[1]
+
+        #predictive probability calculation
+        decisionValue = numpy.zeros((N, C))
+        for n in range(N):
+            decisionValue[n, :] = numpy.dot(feature[n, :], w)
+        return decisionValue
 
     def predict_proba(self, feature):
         """Probability estimates.

--- a/smlr/SMLRsubfunc.py
+++ b/smlr/SMLRsubfunc.py
@@ -13,22 +13,11 @@ def funcE(theta, alpha, Y, X):
     # X: feature matrix, # of samples by # of dimensions
     # output: log likelihood function of theta (averaged over alpha)
 
-    theta = numpy.double(theta)
-    alpha = numpy.double(alpha)
-    X = numpy.double(X)
-
-    N = X.shape[0]
-    D = X.shape[1]
-    C = Y.shape[1]
-    E = 0
-
-    linearSum = numpy.zeros((N, C))
-    for c in range(C):
-        linearSum[:, c] = numpy.dot(X, theta[:, c])
+    linearSum = X.dot(theta)
     fone = numpy.sum(Y * linearSum, axis=1) - \
         numpy.log(numpy.sum(numpy.exp(linearSum), axis=1))
-    E = numpy.sum(fone) - (0.5) * numpy.sum(numpy.reshape(theta, (C * D, 1), order='F') *
-                                            ((numpy.reshape(alpha, (C * D, 1), order='F'))**2))
+    E = numpy.sum(fone) - (0.5) * numpy.sum(theta.ravel(order='F') *
+                                            alpha.ravel(order='F') ** 2)
     return E
 
 # <codecell>
@@ -41,32 +30,21 @@ def gradE(theta, alpha, Y, X):
     # X: feature matrix, # of samples by # of dimensions
     # output: The gragient of funcE. This is used for Q-step optimization.
 
-    theta = numpy.double(theta)
-    alpha = numpy.double(alpha)
-    X = numpy.double(X)
-    N = X.shape[0]
     D = X.shape[1]
     C = Y.shape[1]
 
     dE = numpy.zeros((theta.shape[0] * theta.shape[1], 1))
-    linearSum = numpy.zeros((N, C))
-    p = numpy.zeros((N, C))
-    for c in range(C):
-        linearSum[:, c] = numpy.dot(X, theta[:, c])
-    for n in range(N):
-        p[n, :] = numpy.exp(linearSum[n, :]) / \
-            numpy.sum(numpy.exp(linearSum[n, :]))
+    linearSumExponential = numpy.exp(X.dot(theta))
+    p = linearSumExponential / numpy.sum(
+        linearSumExponential, axis=1)[:, numpy.newaxis]
 
     for c in range(C):
-        temporal_dE = numpy.zeros((D, 1))
-        for n in range(N):
-            temporal_dE = temporal_dE + \
-                (Y[n, c] - p[n, c]) * numpy.transpose([X[n, :]])
-
+        temporal_dE = numpy.sum(
+            (Y[:, c] - p[:, c]) * X.T, axis=1)[:, numpy.newaxis]
         A = numpy.diag(alpha[:, c])
-        temporal_dE = temporal_dE - \
-            numpy.transpose([numpy.dot(A, theta[:, c])])
+        temporal_dE -= numpy.transpose([numpy.dot(A, theta[:, c])])
         dE[c * D:((c + 1) * D), 0] = numpy.squeeze(temporal_dE)
+
     return numpy.squeeze(dE)
 
 # <codecell>
@@ -79,30 +57,21 @@ def HessE(theta, alpha, Y, X):
     # X: feature matrix, # of samples by # of dimensions
     # output: The Hessian of funcE. This is used for Q-step optimization.
 
-    theta = numpy.double(theta)
-    alpha = numpy.double(alpha)
-    X = numpy.double(X)
     N = X.shape[0]
     D = X.shape[1]
     C = Y.shape[1]
 
-    linearSum = numpy.zeros((N, C))
-    p = numpy.zeros((N, C))
-    for c in range(C):
-        linearSum[:, c] = numpy.dot(X, theta[:, c])
-
-    for n in range(N):
-        p[n, :] = numpy.exp(linearSum[n, :]) / \
-            numpy.sum(numpy.exp(linearSum[n, :]))
+    linearSumExponential = numpy.exp(X.dot(theta))
+    p = linearSumExponential / numpy.sum(
+        linearSumExponential, axis=1)[:, numpy.newaxis]
     H = numpy.zeros((C * D, C * D))
 
     for n in range(N):
         M1 = numpy.diag(p[n, :])
         M2 = numpy.dot(numpy.transpose([p[n, :]]), [p[n, :]])
         M3 = numpy.dot(numpy.transpose([X[n, :]]), [X[n, :]])
-        H = H + numpy.kron(M1 - M2, M3)
-    H = -H
-    H = H - numpy.diag(numpy.reshape(alpha, (C * D), order='F'))
+        H = H - numpy.kron(M1 - M2, M3)
+    H = H - numpy.diag(alpha.ravel(order='F'))
     # Derivation came from Yamashita et al., Nuroimage,2008., but
     # exactly speaking, the last term is modified.
     # The above is consistent with SLR toolbox (MATLAB-based implementation by

--- a/smlr/SMLRsubfunc.py
+++ b/smlr/SMLRsubfunc.py
@@ -3,7 +3,6 @@
 
 # <codecell>
 import numpy
-import scipy
 
 
 def funcE(theta, alpha, Y, X):

--- a/smlr/SMLRsubfunc.py
+++ b/smlr/SMLRsubfunc.py
@@ -5,98 +5,106 @@
 import numpy
 import scipy
 
-def funcE(theta,alpha,Y,X):
-    #theta: weights for classification, dimensions by # of classes
-    #alpha: relavance parameters in ARD, dimensions by # of classes
-    #Y: label matrix, 1-of-K representation, # of samples by # of classes
-    #X: feature matrix, # of samples by # of dimensions
-    #output: log likelihood function of theta (averaged over alpha)
-    
-    theta=numpy.double(theta)
-    alpha=numpy.double(alpha)
-    X=numpy.double(X)
-    
-    N=X.shape[0]
-    D=X.shape[1]
-    C=Y.shape[1]
-    E=0
-    
-    linearSum=numpy.zeros((N,C))
+
+def funcE(theta, alpha, Y, X):
+    # theta: weights for classification, dimensions by # of classes
+    # alpha: relavance parameters in ARD, dimensions by # of classes
+    # Y: label matrix, 1-of-K representation, # of samples by # of classes
+    # X: feature matrix, # of samples by # of dimensions
+    # output: log likelihood function of theta (averaged over alpha)
+
+    theta = numpy.double(theta)
+    alpha = numpy.double(alpha)
+    X = numpy.double(X)
+
+    N = X.shape[0]
+    D = X.shape[1]
+    C = Y.shape[1]
+    E = 0
+
+    linearSum = numpy.zeros((N, C))
     for c in range(C):
-        linearSum[:,c]=numpy.dot(X,theta[:,c])
-    fone=numpy.sum(Y*linearSum,axis=1)-numpy.log(numpy.sum(numpy.exp(linearSum),axis=1))
-    E=numpy.sum(fone)-(0.5)*numpy.sum(numpy.reshape(theta,(C*D,1),order='F')*((numpy.reshape(alpha,(C*D,1),order='F'))**2))
+        linearSum[:, c] = numpy.dot(X, theta[:, c])
+    fone = numpy.sum(Y * linearSum, axis=1) - \
+        numpy.log(numpy.sum(numpy.exp(linearSum), axis=1))
+    E = numpy.sum(fone) - (0.5) * numpy.sum(numpy.reshape(theta, (C * D, 1), order='F') *
+                                            ((numpy.reshape(alpha, (C * D, 1), order='F'))**2))
     return E
 
 # <codecell>
 
-def gradE(theta,alpha,Y,X):
-    #theta: weights for classification, dimensions by # of classes
-    #alpha: relavance parameters in ARD, dimensions by # of classes
-    #Y: label matrix, 1-of-K representation, # of samples by # of classes
-    #X: feature matrix, # of samples by # of dimensions
-    #output: The gragient of funcE. This is used for Q-step optimization.
-    
-    theta=numpy.double(theta)
-    alpha=numpy.double(alpha)
-    X=numpy.double(X)
-    N=X.shape[0]
-    D=X.shape[1]
-    C=Y.shape[1]
-    
-    dE=numpy.zeros((theta.shape[0]*theta.shape[1],1))
-    linearSum=numpy.zeros((N,C))
-    p=numpy.zeros((N,C))
+
+def gradE(theta, alpha, Y, X):
+    # theta: weights for classification, dimensions by # of classes
+    # alpha: relavance parameters in ARD, dimensions by # of classes
+    # Y: label matrix, 1-of-K representation, # of samples by # of classes
+    # X: feature matrix, # of samples by # of dimensions
+    # output: The gragient of funcE. This is used for Q-step optimization.
+
+    theta = numpy.double(theta)
+    alpha = numpy.double(alpha)
+    X = numpy.double(X)
+    N = X.shape[0]
+    D = X.shape[1]
+    C = Y.shape[1]
+
+    dE = numpy.zeros((theta.shape[0] * theta.shape[1], 1))
+    linearSum = numpy.zeros((N, C))
+    p = numpy.zeros((N, C))
     for c in range(C):
-        linearSum[:,c]=numpy.dot(X,theta[:,c])
+        linearSum[:, c] = numpy.dot(X, theta[:, c])
     for n in range(N):
-        p[n,:]=numpy.exp(linearSum[n,:])/numpy.sum(numpy.exp(linearSum[n,:]))
-    
+        p[n, :] = numpy.exp(linearSum[n, :]) / \
+            numpy.sum(numpy.exp(linearSum[n, :]))
+
     for c in range(C):
-        temporal_dE=numpy.zeros((D,1))
+        temporal_dE = numpy.zeros((D, 1))
         for n in range(N):
-            temporal_dE=temporal_dE+(Y[n,c]-p[n,c])*numpy.transpose([X[n,:]])
-          
-        A=numpy.diag(alpha[:,c])
-        temporal_dE=temporal_dE-numpy.transpose([numpy.dot(A,theta[:,c])])
-        dE[c*D:((c+1)*D),0]=numpy.squeeze(temporal_dE)
+            temporal_dE = temporal_dE + \
+                (Y[n, c] - p[n, c]) * numpy.transpose([X[n, :]])
+
+        A = numpy.diag(alpha[:, c])
+        temporal_dE = temporal_dE - \
+            numpy.transpose([numpy.dot(A, theta[:, c])])
+        dE[c * D:((c + 1) * D), 0] = numpy.squeeze(temporal_dE)
     return numpy.squeeze(dE)
 
 # <codecell>
 
-def HessE(theta,alpha,Y,X):
-    #theta: weights for classification, dimensions by # of classes
-    #alpha: relavance parameters in ARD, dimensions by # of classes
-    #Y: label matrix, 1-of-K representation, # of samples by # of classes
-    #X: feature matrix, # of samples by # of dimensions
-    #output: The Hessian of funcE. This is used for Q-step optimization.
 
-    theta=numpy.double(theta)
-    alpha=numpy.double(alpha)
-    X=numpy.double(X)
-    N=X.shape[0]
-    D=X.shape[1]
-    C=Y.shape[1]
-    
-    
-    linearSum=numpy.zeros((N,C))
-    p=numpy.zeros((N,C))
+def HessE(theta, alpha, Y, X):
+    # theta: weights for classification, dimensions by # of classes
+    # alpha: relavance parameters in ARD, dimensions by # of classes
+    # Y: label matrix, 1-of-K representation, # of samples by # of classes
+    # X: feature matrix, # of samples by # of dimensions
+    # output: The Hessian of funcE. This is used for Q-step optimization.
+
+    theta = numpy.double(theta)
+    alpha = numpy.double(alpha)
+    X = numpy.double(X)
+    N = X.shape[0]
+    D = X.shape[1]
+    C = Y.shape[1]
+
+    linearSum = numpy.zeros((N, C))
+    p = numpy.zeros((N, C))
     for c in range(C):
-        linearSum[:,c]=numpy.dot(X,theta[:,c])
+        linearSum[:, c] = numpy.dot(X, theta[:, c])
 
     for n in range(N):
-        p[n,:]=numpy.exp(linearSum[n,:])/numpy.sum(numpy.exp(linearSum[n,:]))
-    H=numpy.zeros((C*D,C*D))
-    
+        p[n, :] = numpy.exp(linearSum[n, :]) / \
+            numpy.sum(numpy.exp(linearSum[n, :]))
+    H = numpy.zeros((C * D, C * D))
+
     for n in range(N):
-        M1=numpy.diag(p[n,:])
-        M2=numpy.dot(numpy.transpose([p[n,:]]),[p[n,:]])
-        M3=numpy.dot(numpy.transpose([X[n,:]]),[X[n,:]])
-        H=H+numpy.kron(M1-M2,M3)
-    H=-H
-    H=H-numpy.diag(numpy.reshape(alpha,(C*D),order='F'))
-    #Derivation came from Yamashita et al., Nuroimage,2008., but
-    #exactly speaking, the last term is modified.
-    #The above is consistent with SLR toolbox (MATLAB-based implementation by Yamashita-san) rather than the paper.
+        M1 = numpy.diag(p[n, :])
+        M2 = numpy.dot(numpy.transpose([p[n, :]]), [p[n, :]])
+        M3 = numpy.dot(numpy.transpose([X[n, :]]), [X[n, :]])
+        H = H + numpy.kron(M1 - M2, M3)
+    H = -H
+    H = H - numpy.diag(numpy.reshape(alpha, (C * D), order='F'))
+    # Derivation came from Yamashita et al., Nuroimage,2008., but
+    # exactly speaking, the last term is modified.
+    # The above is consistent with SLR toolbox (MATLAB-based implementation by
+    # Yamashita-san) rather than the paper.
     return H
-

--- a/smlr/SMLRsubfunc.py
+++ b/smlr/SMLRsubfunc.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # <nbformat>3.0</nbformat>
 
-# <codecell>
 import numpy
 
 
@@ -18,8 +17,6 @@ def funcE(theta, alpha, Y, X):
     E = numpy.sum(fone) - (0.5) * numpy.sum(theta.ravel(order='F') *
                                             alpha.ravel(order='F') ** 2)
     return E
-
-# <codecell>
 
 
 def gradE(theta, alpha, Y, X):
@@ -45,8 +42,6 @@ def gradE(theta, alpha, Y, X):
         dE[c * D:((c + 1) * D), 0] = numpy.squeeze(temporal_dE)
 
     return numpy.squeeze(dE)
-
-# <codecell>
 
 
 def HessE(theta, alpha, Y, X):

--- a/smlr/SMLRupdate.py
+++ b/smlr/SMLRupdate.py
@@ -40,7 +40,7 @@ def thetaStep(theta, alpha, Y, X, isEffective):
                 theta_concatenated[index_effective_weight]
         return theta_original
 
-    # set the cost function that will be minimized in the following 
+    # set the cost function that will be minimized in the following
     # optimization
     def func2minimize(theta_concatenated):
         theta_originalShape = thetaConcatenated2thetaOriginalShape(
@@ -74,7 +74,7 @@ def thetaStep(theta, alpha, Y, X, isEffective):
         HessE_used = numpy.delete(HessE_used, dim_ignored[0], axis=1)
         return -HessE_used
 
-    # set the initial value for optimization. we use the current theta for 
+    # set the initial value for optimization. we use the current theta for
     # this.
     x0 = theta.ravel(order='F')[:, numpy.newaxis]
     dim_ignored = isEffective.ravel(order='F')[:, numpy.newaxis]
@@ -94,7 +94,7 @@ def thetaStep(theta, alpha, Y, X, isEffective):
     var = numpy.diag(cov)
     var = thetaConcatenated2thetaOriginalShape(var)
 
-    param = {'mu': mu, 'var': var, 'funcValue' : res['fun']}
+    param = {'mu': mu, 'var': var, 'funcValue': res['fun']}
     return param
 # <codecell>
 
@@ -110,7 +110,8 @@ def alphaStep(alpha, theta, var, isEffective):
     for c in range(C):
         for d in range(D):
             if isEffective[d, c] == 1:
-                newAlpha[d, c] = (1 - alpha[d,c] * var[d,c]) / (theta[d,c] ** 2)
+                newAlpha[d, c] = ((1 - alpha[d, c] * var[d, c]) /
+                                  (theta[d, c] ** 2))
             else:
-                newAlpha[d,c] = 1e+8
+                newAlpha[d, c] = 1e+8
     return newAlpha

--- a/smlr/SMLRupdate.py
+++ b/smlr/SMLRupdate.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # <nbformat>3.0</nbformat>
 
-# <codecell>
-
 import numpy
 import scipy
 import scipy.optimize
@@ -10,8 +8,8 @@ from smlr import SMLRsubfunc
 
 
 def thetaStep(theta, alpha, Y, X, isEffective):
-
     # chack # of dimensions, # of samples, and # of classes
+
     D = X.shape[1]
     C = Y.shape[1]
 
@@ -58,8 +56,8 @@ def thetaStep(theta, alpha, Y, X, isEffective):
         dim_ignored = numpy.nonzero(1 - dim_ignored)
         gradE_used = numpy.delete(gradE_originalShape, dim_ignored[0])
         return -gradE_used
-    # set the Hessian for Newton-CG based optimization
 
+    # set the Hessian for Newton-CG based optimization
     def Hess2minimize(theta_concatenated):
         theta_originalShape = thetaConcatenated2thetaOriginalShape(
             theta_concatenated)
@@ -95,22 +93,15 @@ def thetaStep(theta, alpha, Y, X, isEffective):
 
     param = {'mu': mu, 'var': var, 'funcValue': res['fun']}
     return param
-# <codecell>
 
-
-# <codecell>
 
 def alphaStep(alpha, theta, var, isEffective):
-    # change the type of input values i
-
     D = alpha.shape[0]
     C = alpha.shape[1]
-    newAlpha = alpha
     for c in range(C):
         for d in range(D):
             if isEffective[d, c] == 1:
-                newAlpha[d, c] = ((1 - alpha[d, c] * var[d, c]) /
-                                  (theta[d, c] ** 2))
+                alpha[d, c] = (1 - alpha[d, c] * var[d, c]) / theta[d, c] ** 2
             else:
-                newAlpha[d, c] = 1e+8
-    return newAlpha
+                alpha[d, c] = 1e+8
+    return alpha

--- a/smlr/SMLRupdate.py
+++ b/smlr/SMLRupdate.py
@@ -12,7 +12,6 @@ from smlr import SMLRsubfunc
 def thetaStep(theta, alpha, Y, X, isEffective):
 
     # chack # of dimensions, # of samples, and # of classes
-    N = X.shape[0]
     D = X.shape[1]
     C = Y.shape[1]
 

--- a/smlr/SMLRupdate.py
+++ b/smlr/SMLRupdate.py
@@ -104,7 +104,13 @@ def thetaStep(theta, alpha, Y, X, isEffective):
 def alphaStep(alpha, theta, var, isEffective):
     # change the type of input values i
 
-    effectiveIndices = numpy.where(isEffective[:, 0] == 1)
-    newAlpha = numpy.ones_like(alpha) * 1e+8
-    newAlpha[effectiveIndices] = (1 - alpha * var) / theta ** 2
+    D = alpha.shape[0]
+    C = alpha.shape[1]
+    newAlpha = alpha
+    for c in range(C):
+        for d in range(D):
+            if isEffective[d, c] == 1:
+                newAlpha[d, c] = (1 - alpha[d,c] * var[d,c]) / (theta[d,c] ** 2)
+            else:
+                newAlpha[d,c] = 1e+8
     return newAlpha

--- a/smlr/SMLRupdate.py
+++ b/smlr/SMLRupdate.py
@@ -7,104 +7,118 @@ import numpy
 import scipy
 import scipy.optimize
 from smlr import SMLRsubfunc
-def thetaStep(theta,alpha,Y,X,isEffective):
-    
-    #chack # of dimensions, # of samples, and # of classes
-    N=X.shape[0]
-    D=X.shape[1]
-    C=Y.shape[1]
-    
-    #Take indices for effective features (if alpha > 10^3, that dimension is ignored in the following optimization steps)
-    FeatureNum_effectiveWeight=[]
-    ClassNum_effectiveWeight=[]
+
+
+def thetaStep(theta, alpha, Y, X, isEffective):
+
+    # chack # of dimensions, # of samples, and # of classes
+    N = X.shape[0]
+    D = X.shape[1]
+    C = Y.shape[1]
+
+    # Take indices for effective features (if alpha > 10^3, that dimension is
+    # ignored in the following optimization steps)
+    FeatureNum_effectiveWeight = []
+    ClassNum_effectiveWeight = []
     for c in range(C):
         for d in range(D):
-            if isEffective[d,c] == 1:
+            if isEffective[d, c] == 1:
                 FeatureNum_effectiveWeight.append(d)
                 ClassNum_effectiveWeight.append(c)
-    
-    #Declaration of subfunction. this function transform concatenated effective weight paramters into the original shape
+
+    # Declaration of subfunction. this function transform concatenated
+    # effective weight paramters into the original shape
     def thetaConcatenated2thetaOriginalShape(theta_concatenated):
-        if len(theta_concatenated)!=len(FeatureNum_effectiveWeight):
+        if len(theta_concatenated) != len(FeatureNum_effectiveWeight):
             print("the size of theta_concatenated is wrong")
             import sys
             sys.exit()
-        
-        theta_original=numpy.zeros((D,C))
-        for index_effective_weight in range(len(FeatureNum_effectiveWeight)):
-            theta_original[FeatureNum_effectiveWeight[index_effective_weight],ClassNum_effectiveWeight[index_effective_weight]]=\
-                theta_concatenated[index_effective_weight]
-        
-        return theta_original
-    
-    
-    #set the cost function that will be minimized in the following optimization
-    def func2minimize(theta_concatenated):
-        theta_originalShape=thetaConcatenated2thetaOriginalShape(theta_concatenated)
-        return -SMLRsubfunc.funcE(theta_originalShape,alpha,Y,X)
-    
-    #set the gradient for Newton-CG based optimization
-    def grad2minimize(theta_concatenated):
-        theta_originalShape=thetaConcatenated2thetaOriginalShape(theta_concatenated)
-        gradE_originalShape=SMLRsubfunc.gradE(theta_originalShape,alpha,Y,X)
-        
-        #ignore the dimensions that have large alphas
-        dim_ignored=numpy.reshape(isEffective,(C*D,1),order='F')
-        dim_ignored=numpy.nonzero(1-dim_ignored)
-        gradE_used=numpy.delete(gradE_originalShape,dim_ignored[0])
-        return -gradE_used
-    #set the Hessian for Newton-CG based optimization
-    def Hess2minimize(theta_concatenated):
-        theta_originalShape=thetaConcatenated2thetaOriginalShape(theta_concatenated)
-        HessE_originalShape=SMLRsubfunc.HessE(theta_originalShape,alpha,Y,X)
-        
-        #ignore the dimensions that have large alphas
-        dim_ignored=numpy.reshape(isEffective,(C*D,1),order='F')
-        dim_ignored=numpy.nonzero(1-dim_ignored)
-        HessE_used=numpy.delete(HessE_originalShape,dim_ignored[0],axis=0)
-        HessE_used=numpy.delete(HessE_used,dim_ignored[0],axis=1)
-        return -HessE_used
-    
-    
-    #set the initial value for optimization. we use the current theta for this.
-    x0=numpy.reshape(theta,(C*D,1),order='F')
-    dim_ignored=numpy.reshape(isEffective,(C*D,1),order='F')
-    dim_ignored=numpy.nonzero(1-dim_ignored)
-    x0=numpy.delete(x0,dim_ignored[0])
-    
-    #Optimization of theta (weight paramter) with scipy.optimize.minimize
-    import scipy.optimize
-    res = scipy.optimize.minimize(func2minimize, x0, method='Newton-CG',jac=grad2minimize,hess=Hess2minimize,tol=10**(-3))
-    mu=thetaConcatenated2thetaOriginalShape(res['x'])
-    
-    #The covariance matrix of the posterior distribution
-    cov=numpy.linalg.inv(Hess2minimize(res['x']))
 
-    #The diagonal elements of the above covariance matrix
-    var=numpy.diag(cov)
-    var=thetaConcatenated2thetaOriginalShape(var)
-    
-    param={'mu' : mu , 'var' : var}
+        theta_original = numpy.zeros((D, C))
+        for index_effective_weight in range(len(FeatureNum_effectiveWeight)):
+            theta_original[
+                FeatureNum_effectiveWeight[index_effective_weight],
+                ClassNum_effectiveWeight[index_effective_weight]] =\
+                theta_concatenated[index_effective_weight]
+
+        return theta_original
+
+    # set the cost function that will be minimized in the following 
+    # optimization
+    def func2minimize(theta_concatenated):
+        theta_originalShape = thetaConcatenated2thetaOriginalShape(
+            theta_concatenated)
+        return -SMLRsubfunc.funcE(theta_originalShape, alpha, Y, X)
+
+    # set the gradient for Newton-CG based optimization
+    def grad2minimize(theta_concatenated):
+        theta_originalShape = thetaConcatenated2thetaOriginalShape(
+            theta_concatenated)
+        gradE_originalShape = SMLRsubfunc.gradE(
+            theta_originalShape, alpha, Y, X)
+
+        # ignore the dimensions that have large alphas
+        dim_ignored = numpy.reshape(isEffective, (C * D, 1), order='F')
+        dim_ignored = numpy.nonzero(1 - dim_ignored)
+        gradE_used = numpy.delete(gradE_originalShape, dim_ignored[0])
+        return -gradE_used
+    # set the Hessian for Newton-CG based optimization
+
+    def Hess2minimize(theta_concatenated):
+        theta_originalShape = thetaConcatenated2thetaOriginalShape(
+            theta_concatenated)
+        HessE_originalShape = SMLRsubfunc.HessE(
+            theta_originalShape, alpha, Y, X)
+
+        # ignore the dimensions that have large alphas
+        dim_ignored = numpy.reshape(isEffective, (C * D, 1), order='F')
+        dim_ignored = numpy.nonzero(1 - dim_ignored)
+        HessE_used = numpy.delete(HessE_originalShape, dim_ignored[0], axis=0)
+        HessE_used = numpy.delete(HessE_used, dim_ignored[0], axis=1)
+        return -HessE_used
+
+    # set the initial value for optimization. we use the current theta for 
+    # this.
+    x0 = numpy.reshape(theta, (C * D, 1), order='F')
+    dim_ignored = numpy.reshape(isEffective, (C * D, 1), order='F')
+    dim_ignored = numpy.nonzero(1 - dim_ignored)
+    x0 = numpy.delete(x0, dim_ignored[0])
+
+    # Optimization of theta (weight paramter) with scipy.optimize.minimize
+    import scipy.optimize
+    res = scipy.optimize.minimize(
+        func2minimize, x0, method='Newton-CG',
+        jac=grad2minimize, hess=Hess2minimize, tol=10**(-3))
+    mu = thetaConcatenated2thetaOriginalShape(res['x'])
+
+    # The covariance matrix of the posterior distribution
+    cov = numpy.linalg.inv(Hess2minimize(res['x']))
+
+    # The diagonal elements of the above covariance matrix
+    var = numpy.diag(cov)
+    var = thetaConcatenated2thetaOriginalShape(var)
+
+    param = {'mu': mu, 'var': var}
     return param
 # <codecell>
 
 
 # <codecell>
 
-def alphaStep(alpha,theta,var,isEffective):
-    
-    #change the type of input values i
-    theta=numpy.double(theta)
-    alpha=numpy.double(alpha)
-    var=numpy.double(var)
-    D=alpha.shape[0]
-    C=alpha.shape[1]
-    newAlpha=alpha
+def alphaStep(alpha, theta, var, isEffective):
+
+    # change the type of input values i
+    theta = numpy.double(theta)
+    alpha = numpy.double(alpha)
+    var = numpy.double(var)
+    D = alpha.shape[0]
+    C = alpha.shape[1]
+    newAlpha = alpha
     for c in range(C):
         for d in range(D):
-            if isEffective[d,c] == 1:
-                newAlpha[d,c]=(1-alpha[d,c]*var[d,c])/(theta[d,c]**2)
+            if isEffective[d, c] == 1:
+                newAlpha[d, c] = (1 - alpha[d, c] * var[d, c]
+                                  ) / (theta[d, c]**2)
             else:
-                newAlpha[d,c]=10**8
+                newAlpha[d, c] = 10**8
     return newAlpha
-

--- a/smlr/SMLRupdate.py
+++ b/smlr/SMLRupdate.py
@@ -6,7 +6,7 @@
 import numpy
 import scipy
 import scipy.optimize
-import SMLRsubfunc
+from smlr import SMLRsubfunc
 def thetaStep(theta,alpha,Y,X,isEffective):
     
     #chack # of dimensions, # of samples, and # of classes
@@ -26,7 +26,7 @@ def thetaStep(theta,alpha,Y,X,isEffective):
     #Declaration of subfunction. this function transform concatenated effective weight paramters into the original shape
     def thetaConcatenated2thetaOriginalShape(theta_concatenated):
         if len(theta_concatenated)!=len(FeatureNum_effectiveWeight):
-            print "the size of theta_concatenated is wrong"
+            print("the size of theta_concatenated is wrong")
             import sys
             sys.exit()
         

--- a/smlr/__init__.py
+++ b/smlr/__init__.py
@@ -1,1 +1,1 @@
-from smlr.SMLR import SMLR
+from smlr.SMLR import SMLR  # NOQA

--- a/smlr/__init__.py
+++ b/smlr/__init__.py
@@ -1,1 +1,1 @@
-from SMLR import SMLR
+from smlr.SMLR import SMLR


### PR DESCRIPTION
This PR makes smlr training and prediction about two times faster to rewrite the for-loops to the functions of numpy. Also, I improved the readability of the code applying pep8 and flake8.